### PR TITLE
Make `html` a parameter to the main function

### DIFF
--- a/substitutions.js
+++ b/substitutions.js
@@ -1,4 +1,4 @@
-function xkcdSubstitutions(){
+function xkcdSubstitutions(html){
 	var words = [
 		{find: new RegExp('\\bwitnesses\\b', 'gi'), replace: 'these dudes I know'},
 		{find: new RegExp('\\ballegedly\\b', 'gi'), replace: 'kinda probably'},
@@ -57,13 +57,13 @@ function xkcdSubstitutions(){
 		{find: new RegExp('\\byou won\'t believe\\b', 'gi'), replace: 'I\'m really sad about'}
 	];
 
-	var html = document.body.innerHTML;
+	var newHTML = html;
 	for (var i = 0; i < words.length; i++) {
-		html = html.replace(words[i].find, words[i].replace);
+		newHTML = newHTML.replace(words[i].find, words[i].replace);
 	}
 
-	return html;
+	return newHTML;
 }
 
-document.body.innerHTML=xkcdSubstitutions();
+document.body.innerHTML = xkcdSubstitutions(document.body.innerHTML);
 // vim: noet


### PR DESCRIPTION
The function is more stand-alone and testable if `html` is passed in as a parameter, rather than being read off the page. This mirrors the way that `html` is returned at the end of the function, rather than it being directly assigned to `document.body.innerHTML`.

It is not strictly necessary to create a new variable `newHTML` – reassigning to the parameter `html` does not change the value that was passed into the function. But since JavaScript’s behavior in this case is not obvious, I made the code more explicit so readers wouldn’t worry about the possibility of that bug.
